### PR TITLE
Prevents Faceoffs and Votes tables from trying to dropColumn twice.

### DIFF
--- a/data/migrations/20201210170451__edit-winner-column.js
+++ b/data/migrations/20201210170451__edit-winner-column.js
@@ -5,7 +5,7 @@ exports.up = function (knex) {
 };
 
 exports.down = function (knex) {
-    return knex.schema.table('Faceoffs', table => {
-        table.dropColumn('Winner')
-    });
+    // return knex.schema.table('Faceoffs', table => {
+    //     table.dropColumn('Winner')
+    // });
 };

--- a/data/migrations/20201216145909_change_vote_to_integer.js
+++ b/data/migrations/20201216145909_change_vote_to_integer.js
@@ -1,14 +1,12 @@
 
 exports.up = function(knex) {
     return knex.schema.table('Votes', table => {
-        // ERRLOG: migration file "20201216145909_change_vote_to_integer.js" failed migration failed with error: alter table "Votes" drop column "Vote" - column "Vote" of relation "Votes" does not exist error: alter table "Votes" drop column "Vote" - column "Vote" of relation "Votes" does not exist 
-        //  ----changed from table.dropColumn to table.string
-        table.string('Vote');
+        table.dropColumn('Votes')
     })
 };
 
 exports.down = function(knex) {
-    return knex.schema.table('Votes', table => {
-        table.dropColumn('Vote');
-    });
+    // return knex.schema.table('Votes', table => {
+    //     table.dropColumn('Vote');
+    // });
 };


### PR DESCRIPTION
# Description

Fixes #

In a meeting on 2/24/2021 Story Squad 31 Team B provided Team A with bug fixes regarding two migrations in the Faceoffs table and Votes table that were attempting to dropColumn twice which was causing migrations to break.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## Change Status

- [x] Complete, but not tested (may need new tests)

## Has This Been Tested

- [x] No

## Checklist

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] My code has been reviewed by at least one peer
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] There are no merge conflicts
