### PR TITLE
Feature/team b leader board

### DIFF
--- a/api/leaderboard/leadBoardModel.js
+++ b/api/leaderboard/leadBoardModel.js
@@ -24,14 +24,14 @@ const getLeaderBoardData = async () =>{
         const Name = child.Name;
         const WP = child.WritingPoints
         const DP = child.DrawingPoints
-        // const TP = child.Total_Points
+        const TP = child.Total_Points
         const outputNames = output.map(chil => chil.Name)
         if(outputNames.includes(Name)){
             output.forEach(chil =>{
                 if(chil.Name == Name){
                     chil.WritingPoints = WP;
                     chil.DrawingPoints = DP;
-                    chil.Total_Points = WP + DP;
+                    chil.Total_Points = WP + DP + TP;
                 }
             })
         }else{


### PR DESCRIPTION
# Description

Fixes #

Updates shared by Fernando Chavez in Team B which allow the leaderboard to show the Total Points for a child instead of an incorrect sum of points from a single writing and drawing submission.

These changes were shared in an attempt to help narrow down where points are given to squad winners of a faceoff in order to ensure logic was implemented to split points between the squads in the case of a tie.

Splitting points is a next step/ part of [FT 3] "As a kid user, I want to be able to keep voting after the 3 main votes."

The leaderboard correctly displaying Total Points is part of [FT 1] "As a kid user, I track my stats each week to gauge my progress" which is being worked on by Team B.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Change Status

- [x] Complete, but not tested (may need new tests)

## Has This Been Tested

- [x] No

## Checklist

- [ ] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My code has been reviewed by at least one peer
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] There are no merge conflicts
