### PR TITLE
Feature/keep voting after three

### DIFF
--- a/api/mod/BallotGeneration.js
+++ b/api/mod/BallotGeneration.js
@@ -49,8 +49,8 @@ const VSequence = (squads, data) =>{
     children.forEach(child =>{
         //aquires current squad ID to compare
         let num = child.SquadID
-        //counter to ensure iteration is only 3 times
-        let votesAvailable = 3;
+        //counter to ensure iteration is only 5 times
+        let votesAvailable = 5;
         console.log(squads)
         while(votesAvailable > 0){
             for(let squadNum in squads){

--- a/data/migrations/20210224113245_update_VotesRemaining_to_10_votes.js
+++ b/data/migrations/20210224113245_update_VotesRemaining_to_10_votes.js
@@ -1,0 +1,16 @@
+
+exports.up = function(knex) {
+  return knex.schema
+  .alterTable('Children', table =>{
+      table.integer('VotesRemaining').defaultTo(10).notNullable().alter();
+  })
+};
+
+
+
+exports.down = function(knex) {
+  return knex.schema
+  .table('Children',table =>{
+      table.dropColumn('VotesRemaining');
+  })
+};

--- a/data/seeds/006_Children.js
+++ b/data/seeds/006_Children.js
@@ -16,8 +16,7 @@ const children1 = [...new Array(8)].map((i, idx) => ({
   // Attempting to have wins & losses combine to equal 4 (1 less than the cohort's StoryID, which should be how many weeks/rounds they've finished). Check table to see if it works.
   Wins: `${(idx) % 5}`,        // 0,1,2,3,4,0
   Losses: `${(99 - idx) % 5}`, // 4,3,2,1,0,4
-  Total_Points: `${faker.random.number({ min: 0, max: 400 }) * 4}`,
-  VotesRemaining: 3,
+  Total_Points: `${faker.random.number({ min: 0, max: 400 }) * 4}`
 }));
 
 const children2 = [...new Array(8)].map((i, idx) => ({
@@ -34,8 +33,7 @@ const children2 = [...new Array(8)].map((i, idx) => ({
   // Attempting to have wins & losses combine to equal 3 (1 less than the cohort's StoryID, which should be how many weeks/rounds they've finished). Check table to see if it works.
   Wins: `${(idx) % 4}`,        // 0,1,2,3,4,0
   Losses: `${(99 - idx) % 4}`, // 4,3,2,1,0,4
-  Total_Points: `${faker.random.number({ min: 0, max: 400 }) * 3}`,
-  VotesRemaining: 3,
+  Total_Points: `${faker.random.number({ min: 0, max: 400 }) * 3}`
 }));
 
 const children3 = [...new Array(8)].map((i, idx) => ({
@@ -52,8 +50,7 @@ const children3 = [...new Array(8)].map((i, idx) => ({
   // Attempting to have wins & losses combine to equal 1 (1 less than the cohort's StoryID, which should be how many weeks/rounds they've finished). Check table to see if it works.
   Wins: `${(idx) % 2}`,        // 0,1,2,3,4,0
   Losses: `${(99 - idx) % 2}`, // 4,3,2,1,0,4
-  Total_Points: `${faker.random.number({ min: 0, max: 400 }) * 1}`,
-  VotesRemaining: 3,
+  Total_Points: `${faker.random.number({ min: 0, max: 400 }) * 1}`
 }));
 
 const children4 = [...new Array(8)].map((i, idx) => ({
@@ -68,8 +65,7 @@ const children4 = [...new Array(8)].map((i, idx) => ({
   // Wins & losses combine to equal 0, bc it's cohort 4's first time playing.
   Wins: `0`,
   Losses: `0`,
-  Total_Points: 0,
-  VotesRemaining: 3,
+  Total_Points: 0
 }));
 
 const children = children1.concat(children2, children3, children4)


### PR DESCRIPTION
# Description

`votesAvailable` in `BallotGeneration.js` changed from 3 to 5. This allows us to then generate 10 faceoffs from the ballots rather than the 6 we were generating.

Creates a new migration which alters the default value for `VotesRemaining` in the `Children` table from 3 to 10 which will allow users to vote up to 10 times.

Removes `Total_Points` from the `Children` seed data so that the updated default value of 10 will be used.

These changes are for [FT 3] "As a kid user, I want to be able to keep voting after the 3 main votes"

## Type of change

- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update

## Change Status

- [x] Complete, but not tested (may need new tests)

## Has This Been Tested

- [x] No

## Checklist

- [x] I have performed a self-review of my own code
- [x] My code has been reviewed by at least one peer
- [x] My changes generate no new warnings
- [x] There are no merge conflicts
