### PR TITLE
chore: added knex config for new staging server (dev database)

### DIFF
--- a/config/knexfile.js
+++ b/config/knexfile.js
@@ -35,4 +35,11 @@ module.exports = {
     migrations: { directory: '../data/migrations' },
     seeds: { directory: '../data/seeds' },
   },
+
+  staging: {
+    client: 'pg',
+    connection: process.env.DATABASE_URL,
+    migrations: { directory: '../data/migrations' },
+    seeds: { directory: '../data/seeds' },
+  },
 };


### PR DESCRIPTION
# Description

Fixes #

Knex file configuration was done to allow knex connection to the staging database.  "staging" environment was added, this was done to allow us to migrate and run seeding on our staging server for development mode.  This is referring to creating a developer mode that is separate from influencing the production database.

## Type of change
Chore/Feature

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update

## Change Status

- [x] Complete, but not tested (may need new tests)
Will test the heroku migrations shortly after the PR is merged.

## Has This Been Tested

- [ ] Yes
- [x] No
- [ ] Not necessary

## Checklist

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] My code has been reviewed by at least one peer
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] There are no merge conflicts
