### PR TITLE
Staging

### DIFF
--- a/api/app.js
+++ b/api/app.js
@@ -35,6 +35,7 @@ const gameRouter = require('./game/gameRouter');
 const resetRouter = require('./reset/resetRouter');
 const leadBoard = require('./leaderboard/leadboardRouter');
 const achievements = require('./Achievements/achieveRouter');
+const dev = require('./dev/devModeRouter');
 
 const app = express();
 
@@ -75,6 +76,7 @@ app.use('/game', gameRouter);
 app.use('/reset', resetRouter);
 app.use('/leaderboard', leadBoard);
 app.use('/achievements', achievements);
+app.use('/dev', dev);
 
 // catch 404 and forward to error handler
 app.use(function (req, res, next) {

--- a/api/dev/devModeModel.js
+++ b/api/dev/devModeModel.js
@@ -1,0 +1,52 @@
+const faker = require('faker');
+const db = require('../../data/db-config');
+
+/**
+ * This query marks the submission with the given ID as having HasRead, HasWritten, and HasDrawn set to false, and uploads/deletes submissions accordingly.
+ * @param {number} ID the ID of the submission to be marked as read
+ * @param {boolean} hasRead boolean to indicate whether db should set hasRead to true or false
+ * @param {boolean} hasDrawn boolean to indicate whether db should set hasDrawn to true or false
+ * @param {boolean} hasWritten boolean to indicate whether db should set hasWritten to true or false
+ * @returns {Promise} returns a promise that resolves to the count of fields updated
+ */
+ const updateAll = async (ID, hasRead, hasDrawn, hasWritten) => {
+    /**
+     * This monolithic function is a transaction
+     * uploads submissions depending on booleans (hasDrawn, hasWritten), either adding/removing/ignoring
+     * updates submission tasks depending on booleans
+     */
+    return db.transaction(async (trx) => {
+      try {
+  
+        const preExistingUserDrawing = await db('Drawing').where({ SubmissionID: ID });
+        if(hasDrawn){
+          if(preExistingUserDrawing.length < 1){
+            const newDraw = await trx('Drawing').insert({  URL: faker.image.imageUrl(), SubmissionID: ID  });
+          }
+        } else {
+          if(preExistingUserDrawing.length > 0){
+            await trx('Drawing').where({ SubmissionID: ID }).del();
+          };
+        };
+  
+        const preExistingUserWriting = await db('Writing').where({ SubmissionID: ID });
+        if(hasWritten){
+          if(preExistingUserWriting.length < 1){
+            await trx('Writing').insert({ URL:faker.image.imageUrl(), PageNum: 1, SubmissionID: ID });
+          }
+        } else {
+          if(preExistingUserWriting.length > 0) {
+            await trx('Writing').where({ SubmissionID: ID }).del();
+          }
+        }
+        await trx('Submissions').where({ ID }).update({ HasRead: hasRead, HasWritten: hasWritten, HasDrawn: hasDrawn });
+      } catch(err) {
+        throw new Error(err.message);
+      }
+    });
+  
+  }
+
+  module.exports = {
+      updateAll,
+  }

--- a/api/dev/devModeModel.js
+++ b/api/dev/devModeModel.js
@@ -21,7 +21,7 @@ const db = require('../../data/db-config');
         const preExistingUserDrawing = await db('Drawing').where({ SubmissionID: ID });
         if(hasDrawn){
           if(preExistingUserDrawing.length < 1){
-            const newDraw = await trx('Drawing').insert({  URL: faker.image.imageUrl(), SubmissionID: ID  });
+            await trx('Drawing').insert({  URL: faker.image.imageUrl(), SubmissionID: ID  });
           }
         } else {
           if(preExistingUserDrawing.length > 0){

--- a/api/dev/devModeRouter.js
+++ b/api/dev/devModeRouter.js
@@ -1,0 +1,58 @@
+const router = require('express').Router();
+
+const { authRequired, validateUpdateAllTasksParams } = require('../middleware');
+const { crudOperationsManager } = require('../../lib');
+const DevModel = require('./devModeModel');
+
+
+/**
+ * @swagger
+ * /submit/update-all/{id}:
+ *  put:
+ *    summary: Attempts to mark the submission with the given ID as hasRead as 'false', hasWritten as 'false', hasDrawn as 'false'
+ *    security:
+ *      - okta: []
+ *    tags:
+ *      - Submissions
+ *    parameters:
+ *      - $ref: '#/components/parameters/submissionId'
+ *      - in: formData
+ *        name: hasRead
+ *        type: boolean
+ *        description: boolean to set users task hasRead to
+ *      - in: formData
+ *        name: hasDrawn
+ *        type: boolean
+ *        description: boolean to set users task hasDrawn to
+*      - in: formData
+ *        name: hasWritten
+ *        type: boolean
+ *        description: boolean to set users task hasWritten to
+ *    responses:
+ *      204:
+ *        $ref: '#/components/responses/EmptySuccess'
+ *      400:
+ *        description: Invalid request missing/invalid arguments
+ *        content:
+ *          application/json:
+ *            schema:
+ *              type: object
+ *              properties:
+ *                error:
+ *                  type: string
+ *                  description: Required inputs hasRead, hasDrawn, and hasWritten must be of boolean type
+ *      401:
+ *        $ref: '#/components/responses/UnauthorizedError'
+ *      404:
+ *        $ref: '#/components/responses/NotFound'
+ *      500:
+ *        $ref: '#/components/responses/DatabaseError'
+ */
+router.put('/update-all/:id', authRequired, validateUpdateAllTasksParams, async (req, res) => {
+    const { id } = req.params;
+    const { hasRead, hasDrawn, hasWritten } = req.body;
+  
+    return crudOperationsManager.update(res, DevModel.updateAll, 'Submission', id, hasRead, hasDrawn, hasWritten);
+  })
+
+  module.exports = router;

--- a/api/submission/submissionModel.js
+++ b/api/submission/submissionModel.js
@@ -1,3 +1,5 @@
+const faker = require('faker');
+
 const db = require('../../data/db-config');
 const _omit = require('lodash.omit');
 
@@ -60,7 +62,7 @@ const markAsRead = (ID, flag = true) => {
 };
 
 /**
- * This query marks the submission with the given ID as having HasRead, HasWritten, and HasDrawn set to false.
+ * This query marks the submission with the given ID as having HasRead, HasWritten, and HasDrawn set to false, and uploads/deletes submissions accordingly.
  * @param {number} ID the ID of the submission to be marked as read
  * @param {boolean} hasRead boolean to indicate whether db should set hasRead to true or false
  * @param {boolean} hasDrawn boolean to indicate whether db should set hasDrawn to true or false
@@ -68,9 +70,41 @@ const markAsRead = (ID, flag = true) => {
  * @returns {Promise} returns a promise that resolves to the count of fields updated
  */
 const updateAll = async (ID, hasRead, hasDrawn, hasWritten) => {
-  res = await db('Submissions').where({ ID }).update({ HasRead: hasRead, HasWritten: hasWritten, HasDrawn: hasDrawn });
-  console.log('res: ', res);
-  return res;
+  /**
+   * This monolithic function is a transaction
+   * uploads submissions depending on booleans (hasDrawn, hasWritten), either adding/removing/ignoring
+   * updates submission tasks depending on booleans
+   */
+  return db.transaction(async (trx) => {
+    try {
+
+      const preExistingUserDrawing = await db('Drawing').where({ SubmissionID: ID });
+      if(hasDrawn){
+        if(preExistingUserDrawing.length < 1){
+          const newDraw = await trx('Drawing').insert({  URL: faker.image.imageUrl(), SubmissionID: ID  });
+        }
+      } else {
+        if(preExistingUserDrawing.length > 0){
+          await trx('Drawing').where({ SubmissionID: ID }).del();
+        };
+      };
+
+      const preExistingUserWriting = await db('Writing').where({ SubmissionID: ID });
+      if(hasWritten){
+        if(preExistingUserWriting.length < 1){
+          await trx('Writing').insert({ URL:faker.image.imageUrl(), PageNum: 1, SubmissionID: ID });
+        }
+      } else {
+        if(preExistingUserWriting.length > 0) {
+          await trx('Writing').where({ SubmissionID: ID }).del();
+        }
+      }
+      await trx('Submissions').where({ ID }).update({ HasRead: hasRead, HasWritten: hasWritten, HasDrawn: hasDrawn });
+    } catch(err) {
+      throw new Error(err.message);
+    }
+  });
+
 }
 
 /**

--- a/api/submission/submissionModel.js
+++ b/api/submission/submissionModel.js
@@ -1,5 +1,3 @@
-const faker = require('faker');
-
 const db = require('../../data/db-config');
 const _omit = require('lodash.omit');
 
@@ -60,52 +58,6 @@ const getAllSubmissionsByChild = (ChildID) => {
 const markAsRead = (ID, flag = true) => {
   return db('Submissions').where({ ID }).update({ HasRead: flag });
 };
-
-/**
- * This query marks the submission with the given ID as having HasRead, HasWritten, and HasDrawn set to false, and uploads/deletes submissions accordingly.
- * @param {number} ID the ID of the submission to be marked as read
- * @param {boolean} hasRead boolean to indicate whether db should set hasRead to true or false
- * @param {boolean} hasDrawn boolean to indicate whether db should set hasDrawn to true or false
- * @param {boolean} hasWritten boolean to indicate whether db should set hasWritten to true or false
- * @returns {Promise} returns a promise that resolves to the count of fields updated
- */
-const updateAll = async (ID, hasRead, hasDrawn, hasWritten) => {
-  /**
-   * This monolithic function is a transaction
-   * uploads submissions depending on booleans (hasDrawn, hasWritten), either adding/removing/ignoring
-   * updates submission tasks depending on booleans
-   */
-  return db.transaction(async (trx) => {
-    try {
-
-      const preExistingUserDrawing = await db('Drawing').where({ SubmissionID: ID });
-      if(hasDrawn){
-        if(preExistingUserDrawing.length < 1){
-          const newDraw = await trx('Drawing').insert({  URL: faker.image.imageUrl(), SubmissionID: ID  });
-        }
-      } else {
-        if(preExistingUserDrawing.length > 0){
-          await trx('Drawing').where({ SubmissionID: ID }).del();
-        };
-      };
-
-      const preExistingUserWriting = await db('Writing').where({ SubmissionID: ID });
-      if(hasWritten){
-        if(preExistingUserWriting.length < 1){
-          await trx('Writing').insert({ URL:faker.image.imageUrl(), PageNum: 1, SubmissionID: ID });
-        }
-      } else {
-        if(preExistingUserWriting.length > 0) {
-          await trx('Writing').where({ SubmissionID: ID }).del();
-        }
-      }
-      await trx('Submissions').where({ ID }).update({ HasRead: hasRead, HasWritten: hasWritten, HasDrawn: hasDrawn });
-    } catch(err) {
-      throw new Error(err.message);
-    }
-  });
-
-}
 
 /**
  * This query is transactional, and runs a series of requests:
@@ -205,7 +157,6 @@ module.exports = {
   getOrInitSubmission,
   getAllSubmissionsByChild,
   markAsRead,
-  updateAll,
   submitDrawingTransaction,
   submitWritingTransaction,
   deleteWritingSubmission,

--- a/api/submission/submissionRouter.js
+++ b/api/submission/submissionRouter.js
@@ -404,7 +404,6 @@ router.post('/draw/:id', authRequired, fileUpload, async (req, res) => {
 router.put('/update-all/:id', authRequired, validateUpdateAllTasksParams, async (req, res) => {
   const { id } = req.params;
   const { hasRead, hasDrawn, hasWritten } = req.body;
-  console.log('tasks: ', hasRead, hasDrawn, hasWritten);
 
   return crudOperationsManager.update(res, Submissions.updateAll, 'Submission', id, hasRead, hasDrawn, hasWritten);
 })

--- a/api/submission/submissionRouter.js
+++ b/api/submission/submissionRouter.js
@@ -360,56 +360,6 @@ router.post('/draw/:id', authRequired, fileUpload, async (req, res) => {
 
 /**
  * @swagger
- * /submit/update-all/{id}:
- *  put:
- *    summary: Attempts to mark the submission with the given ID as hasRead as 'false', hasWritten as 'false', hasDrawn as 'false'
- *    security:
- *      - okta: []
- *    tags:
- *      - Submissions
- *    parameters:
- *      - $ref: '#/components/parameters/submissionId'
- *      - in: formData
- *        name: hasRead
- *        type: boolean
- *        description: boolean to set users task hasRead to
- *      - in: formData
- *        name: hasDrawn
- *        type: boolean
- *        description: boolean to set users task hasDrawn to
-*      - in: formData
- *        name: hasWritten
- *        type: boolean
- *        description: boolean to set users task hasWritten to
- *    responses:
- *      204:
- *        $ref: '#/components/responses/EmptySuccess'
- *      400:
- *        description: Invalid request missing/invalid arguments
- *        content:
- *          application/json:
- *            schema:
- *              type: object
- *              properties:
- *                error:
- *                  type: string
- *                  description: Required inputs hasRead, hasDrawn, and hasWritten must be of boolean type
- *      401:
- *        $ref: '#/components/responses/UnauthorizedError'
- *      404:
- *        $ref: '#/components/responses/NotFound'
- *      500:
- *        $ref: '#/components/responses/DatabaseError'
- */
-router.put('/update-all/:id', authRequired, validateUpdateAllTasksParams, async (req, res) => {
-  const { id } = req.params;
-  const { hasRead, hasDrawn, hasWritten } = req.body;
-
-  return crudOperationsManager.update(res, Submissions.updateAll, 'Submission', id, hasRead, hasDrawn, hasWritten);
-})
-
-/**
- * @swagger
  * /submission/write/{id}:
  *  delete:
  *    summary: Attempts to delete the writing submission with the specified submission ID.


### PR DESCRIPTION
# Description

Fixes #

- What work was done?
- DevMode set-all API call now resides in dev folder and /dev/ route, made corresponding logic to add/remove submissions depending on what submission task statuses are being set to.  Unit tests should ideally be added.
- Why was this work done?
- To allow developers to simulate thursday, since clustering relies on submissions
- What feature / user story is it for?
- As a developer, I want to be able to pick a particular game stage and simulate it.

## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)

## Change Status

- [x] Complete, but not tested (may need new tests)

## Has This Been Tested

- [x] No

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My code has been reviewed by at least one peer
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] There are no merge conflicts
