### PR TITLE
Update name of environment variables from Okta to Auth0

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -4,8 +4,6 @@ DS_API_URL=http://localhost:8002
 DS_API_TOKEN=SUPERSECRET
 DATABASE_URL=<enter postrges url>
 NODE_ENV=production
-
-OKTA_URL_ISSUER=https://auth.lambdalabs.dev/oauth2/default
-
-OKTA_CLIENT_ID=<enter okta client id>
-OKTA_ORG_URL=https://lambdaschoolsso.okta.com/
+AUTH0_CLIENT_ID = <enter auth0 client id. looks like a bunch of letters and numbers>
+AUTH0_DOMAIN = <enter auth0 domain>
+AUTH0_AUDIENCE = <enter auth0 audience here. looks like https://enterauth0domainhere/api/v2>

--- a/README.md
+++ b/README.md
@@ -24,15 +24,15 @@ Labs teams must follow all [Labs Engineering Standards](https://labs.lambdaschoo
 - `DS_API_URL` - URL to a data science api. (eg. <https://ds-bw-test.herokuapp.com/>)
 - `DS_API_TOKEN` - authorization header token for data science api (eg. SUPERSECRET)
 - `DATABASE_URL` - connection string for postgres database
-- `OKTA_URL_ISSUER` - The complete issuer URL for verifying okta access tokens. `https://auth.lambdalabs.dev/oauth2/default`
-- `OKTA_CLIENT_ID` - the okta client ID.
 - `TEST_DATABASE_URL` - the URL of the testing database
-- `OKTA_ORG_URL` - the URL of your Okta organization
 - `NODE_ENV` - The environment to use for knex scripts, should be development on local and production on live server
 - `AWS_ACCESS_KEY_ID` - A special access key from AWS
 - `AWS_SECRET_ACCESS_KEY` - A secret AWS access key that should not be shared with anyone
 - `CI_DATABASE_URL` - the URL of the web-hosted database (I used [ElephantSQL](http://elephantsql.com)) that your CI tests are ran on. This must be set in order to use the `knex:ci` script in the `package.json` !
 - `S3_BUCKET` - the name of the S3 bucket used for file storage
+- `AUTH0_CLIENT_ID` - the Auth0 client id
+- `AUTH0_DOMAIN` - the Auth0 domain
+- `AUTH0_AUDIENCE` - the Auth0 audience
 
 See .env.sample for example values
 


### PR DESCRIPTION
# Description
This is a simple update in the readme and .env sample files to replace the name of the environment variables from Okta to Auth0.

## Fixes

- Changed environment variable names and explanations from Okta to Auth0 because we are switching authentication services
Trello: [https://trello.com/c/XBJXwWGD](url)
